### PR TITLE
Download entire library

### DIFF
--- a/gamdl/cli.py
+++ b/gamdl/cli.py
@@ -358,7 +358,10 @@ def main(
         current_url = f"URL {url_index}/{len(urls)}"
         try:
             logger.debug(f'({current_url}) Checking "{url}"')
-            download_queue.append(downloader.get_download_queue(url))
+            if url == "library":
+                download_queue.append(downloader.get_download_queue_library())
+            else:
+                download_queue.append(downloader.get_download_queue(url))
         except Exception:
             error_count += 1
             logger.error(


### PR DESCRIPTION
This PR adds an ability to download an entire user's music library.  
How to use: use "library" instead of URL, like `gamdl library`. The script will fetch all tracks from the library and download them.  
Small caveats:
 - User's uploaded songs aren't downloaded
 - Some songs has `catalog_id`, but they aren't in the catalog anymore, like `1660614296`, hence the `try ... except`
 - Parsing an entire library can be slow, around 4 min / 1000 songs