### PR TITLE
Added support for configuration from ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,44 +41,44 @@ A Python script to download Apple Music songs/music videos/albums/playlists. Thi
     ```
 
 ## Configuration
-You can configure gamdl by using the command line arguments or the config file. The config file is created automatically when you run gamdl for the first time at `~/.gamdl/config.json` on Linux and `%USERPROFILE%\.gamdl\config.json` on Windows. Config file values can be overridden using command line arguments.
-| Command line argument / Config file key                         | Description                                                            | Default value                      |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
-| `-f`, `--final-path` / `final_path`                             | Path where the downloaded files will be saved.                         | `./Apple Music`                    |
-| `-t`, `--temp-path` / `temp_path`                               | Path where the temporary files will be saved.                          | `./temp`                           |
-| `-c`, `--cookies-location` / `cookies_location`                 | Location of the cookies file.                                          | `./cookies.txt`                    |
-| `-w`, `--wvd-location` / `wvd_location`                         | Location of the .wvd file.                                             | `./device.wvd`                     |
-| `--ffmpeg-location` / `ffmpeg_location`                         | Location of the FFmpeg binary.                                         | `ffmpeg`                           |
-| `--mp4box-location` / `mp4box_location`                         | Location of the MP4Box binary.                                         | `MP4Box`                           |
-| `--mp4decrypt-location` / `mp4decrypt_location`                 | Location of the mp4decrypt binary.                                     | `mp4decrypt`                       |
-| `--nm3u8dlre-location` / `nm3u8dlre_location`                   | Location of the N_m3u8DL-RE binary.                                    | `N_m3u8DL-RE`                      |
-| `--config-location` / -                                         | Location of the config file.                                           | `<home_folder>/.gamdl/config.json` |
-| `--template-folder-album` / `template_folder_album`             | Template of the album folders as a format string.                      | `{album_artist}/{album}`           |
-| `--template-folder-compilation` / `template_folder_compilation` | Template of the compilation album folders as a format string.          | `Compilations/{album}`             |
-| `--template-file-single-disc` / `template_file_single_disc`     | Template of the track files for single-disc albums as a format string. | `{track:02d} {title}`              |
-| `--template-file-multi-disc` / `template_file_multi_disc`       | Template of the track files for multi-disc albums as a format string.  | `{disc}-{track:02d} {title}`       |
-| `--template-folder-music-video` / `template_folder_music_video` | Template of the music video folders as a format string.                | `{artist}/Unknown Album`           |
-| `--template-file-music-video` / `template_file_music_video`     | Template of the music video files as a format string.                  | `{title}`                          |
-| `--cover-size` / `cover_size`                                   | Size of the cover.                                                     | `1200`                             |
-| `--template-date` / `template_date`                             | Template of the tagged date as a string with format codes.             | `%Y-%m-%dT%H:%M:%SZ`               |
-| `--cover-format` / `cover_format`                               | Format of the cover.                                                   | `jpg`                              |
-| `--remux-mode` / `remux_mode`                                   | Remux mode.                                                            | `ffmpeg`                           |
-| `--download-mode` / `download_mode`                             | Download mode.                                                         | `ytdlp`                            |
-| `-e`, `--exclude-tags` / `exclude_tags`                         | List of tags to exclude from file tagging separated by commas.         | `null`                             |
-| `--truncate` / `truncate`                                       | Maximum length of the file/folder names.                               | `40`                               |
-| `-l`, `--log-level` / `log_level`                               | Log level.                                                             | `INFO`                             |
-| `--prefer-hevc` / `prefer_hevc`                                 | Prefer HEVC over AVC when downloading music videos.                    | `false`                            |
-| `--prefer-account-language` / `prefer_account_language`         | Prefer the language associated with the account rather than English.   | `false`                            |
-| `--ask-video-format` / `ask_video_format`                       | Ask for the video format when downloading music videos.                | `false`                            |
-| `--disable-music-video-skip` / `disable_music_video_skip`       | Don't skip downloading music videos in albums/playlists.               | `false`                            |
-| `-l`, `--lrc-only` / `lrc_only`                                 | Download only the synced lyrics.                                       | `false`                            |
-| `-n`, `--no-lrc` / `no_lrc`                                     | Don't download the synced lyrics.                                      | `false`                            |
-| `-s`, `--save-cover` / `save_cover`                             | Save cover as a separate file.                                         | `false`                            |
-| `--songs-heaac` / `songs_heaac`                                 | Download songs in HE-AAC 64kbps.                                       | `false`                            |
-| `-o`, `--overwrite` / `overwrite`                               | Overwrite existing files.                                              | `false`                            |
-| `--print-exceptions` / `print_exceptions`                       | Print exceptions.                                                      | `false`                            |
-| `-u`, `--url-txt` / -                                           | Read URLs as location of text files containing URLs.                   | `false`                            |
-| `-n`, `--no-config-file` / -                                    | Don't use the config file.                                             | `false`                            |
+You can configure gamdl by using the command line arguments, environment variables, or the config file. The config file is created automatically when you run gamdl for the first time at `~/.gamdl/config.json` on Linux and `%USERPROFILE%\.gamdl\config.json` on Windows. Config file values and environment variables can be overridden using command line arguments.
+| Command line argument           | Config file key               | Environment Variable                | Description                                                            | Default value                      |
+| ------------------------------- | ----------------------------- | ----------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
+| `-f`, `--final-path`            | `final_path`                  | `GAMDL_FINAL_PATH`                  | Path where the downloaded files will be saved.                         | `./Apple Music`                    |
+| `-t`, `--temp-path`             | `temp_path`                   | `GAMDL_TEMP_PATH`                   | Path where the temporary files will be saved.                          | `./temp`                           |
+| `-c`, `--cookies-location`      | `cookies_location`            | `GAMDL_COOKIES_LOCATION`            | Location of the cookies file.                                          | `./cookies.txt`                    |
+| `-w`, `--wvd-location`          | `wvd_location`                | `GAMDL_WVD_LOCATION`                | Location of the .wvd file.                                             | `./device.wvd`                     |
+| `--ffmpeg-location`             | `ffmpeg_location`             | `GAMDL_FFMPEG_LOCATION`             | Location of the FFmpeg binary.                                         | `ffmpeg`                           |
+| `--mp4box-location`             | `mp4box_location`             | `GAMDL_MP4BOX_LOCATION`             | Location of the MP4Box binary.                                         | `MP4Box`                           |
+| `--mp4decrypt-location`         | `mp4decrypt_location`         | `GAMDL_MP4DECRYPT_LOCATION`         | Location of the mp4decrypt binary.                                     | `mp4decrypt`                       |
+| `--nm3u8dlre-location`          | `nm3u8dlre_location`          | `GAMDL_NM3U8DLRE_LOCATION`          | Location of the N_m3u8DL-RE binary.                                    | `N_m3u8DL-RE`                      |
+| `--config-location`             | -                             | `GAMDL_CONFIG_LOCATION`             | Location of the config file.                                           | `<home_folder>/.gamdl/config.json` |
+| `--template-folder-album`       | `template_folder_album`       | `GAMDL_TEMPLATE_FOLDER_ALBUM`       | Template of the album folders as a format string.                      | `{album_artist}/{album}`           |
+| `--template-folder-compilation` | `template_folder_compilation` | `GAMDL_TEMPLATE_FOLDER_COMPILATION` | Template of the compilation album folders as a format string.          | `Compilations/{album}`             |
+| `--template-file-single-disc`   | `template_file_single_disc`   | `GAMDL_TEMPLATE_FILE_SINGLE_DISC`   | Template of the track files for single-disc albums as a format string. | `{track:02d} {title}`              |
+| `--template-file-multi-disc`    | `template_file_multi_disc`    | `GAMDL_TEMPLATE_FILE_MULTI_DISC`    | Template of the track files for multi-disc albums as a format string.  | `{disc}-{track:02d} {title}`       |
+| `--template-folder-music-video` | `template_folder_music_video` | `GAMDL_TEMPLATE_FOLDER_MUSIC_VIDEO` | Template of the music video folders as a format string.                | `{artist}/Unknown Album`           |
+| `--template-file-music-video`   | `template_file_music_video`   | `GAMDL_TEMPLATE_FILE_MUSIC_VIDEO`   | Template of the music video files as a format string.                  | `{title}`                          |
+| `--cover-size`                  | `cover_size`                  | `GAMDL_COVER_SIZE`                  | Size of the cover.                                                     | `1200`                             |
+| `--template-date`               | `template_date`               | `GAMDL_TEMPLATE_DATE`               | Template of the tagged date as a string with format codes.             | `%Y-%m-%dT%H:%M:%SZ`               |
+| `--cover-format`                | `cover_format`                | `GAMDL_COVER_FORMAT`                | Format of the cover.                                                   | `jpg`                              |
+| `--remux-mode`                  | `remux_mode`                  | `GAMDL_REMUX_MODE`                  | Remux mode.                                                            | `ffmpeg`                           |
+| `--download-mode`               | `download_mode`               | `GAMDL_DOWNLOAD_MODE`               | Download mode.                                                         | `ytdlp`                            |
+| `-e`, `--exclude-tags`          | `exclude_tags`                | `GAMDL_EXCLUDE_TAGS`                | List of tags to exclude from file tagging separated by commas.         | `null`                             |
+| `--truncate`                    | `truncate`                    | `GAMDL_TRUNCATE`                    | Maximum length of the file/folder names.                               | `40`                               |
+| `-l`, `--log-level`             | `log_level`                   | `GAMDL_LOG_LEVEL`                   | Log level.                                                             | `INFO`                             |
+| `--prefer-hevc`                 | `prefer_hevc`                 | `GAMDL_PREFER_HEVC`                 | Prefer HEVC over AVC when downloading music videos.                    | `false`                            |
+| `--prefer-account-language`     | `prefer_account_language`     | `GAMDL_PREFER_ACCOUNT_LANGUAGE`     | Prefer the language associated with the account rather than English.   | `false`                            |
+| `--ask-video-format`            | `ask_video_format`            | `GAMDL_ASK_VIDEO_FORMAT`            | Ask for the video format when downloading music videos.                | `false`                            |
+| `--disable-music-video-skip`    | `disable_music_video_skip`    | `GAMDL_DISABLE_MUSIC_VIDEO_SKIP`    | Don't skip downloading music videos in albums/playlists.               | `false`                            |
+| `-l`, `--lrc-only`              | `lrc_only`                    | `GAMDL_LRC_ONLY`                    | Download only the synced lyrics.                                       | `false`                            |
+| `-n`, `--no-lrc`                | `no_lrc`                      | `GAMDL_NO_LRC`                      | Don't download the synced lyrics.                                      | `false`                            |
+| `-s`, `--save-cover`            | `save_cover`                  | `GAMDL_SAVE_COVER`                  | Save cover as a separate file.                                         | `false`                            |
+| `--songs-heaac`                 | `songs_heaac`                 | `GAMDL_SONGS_HEAAC`                 | Download songs in HE-AAC 64kbps.                                       | `false`                            |
+| `-o`, `--overwrite`             | `overwrite`                   | `GAMDL_OVERWRITE`                   | Overwrite existing files.                                              | `false`                            |
+| `--print-exceptions`            | `print_exceptions`            | `GAMDL_PRINT_EXCEPTIONS`            | Print exceptions.                                                      | `false`                            |
+| `-u`, `--url-txt`               | -                             | `GAMDL_URL_TXT`                     | Read URLs as location of text files containing URLs.                   | `false`                            |
+| `-n`, `--no-config-file`        | -                             | `GAMDL_NO_CONFIG_FILE`              | Don't use the config file.                                             | `false`                            |
 
 
 ### Tags variables

--- a/README.md
+++ b/README.md
@@ -41,44 +41,44 @@ A Python script to download Apple Music songs/music videos/albums/playlists. Thi
     ```
 
 ## Configuration
-You can configure gamdl by using the command line arguments, environment variables, or the config file. The config file is created automatically when you run gamdl for the first time at `~/.gamdl/config.json` on Linux and `%USERPROFILE%\.gamdl\config.json` on Windows. Config file values and environment variables can be overridden using command line arguments.
-| Command line argument           | Config file key               | Environment Variable                | Description                                                            | Default value                      |
-| ------------------------------- | ----------------------------- | ----------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
-| `-f`, `--final-path`            | `final_path`                  | `GAMDL_FINAL_PATH`                  | Path where the downloaded files will be saved.                         | `./Apple Music`                    |
-| `-t`, `--temp-path`             | `temp_path`                   | `GAMDL_TEMP_PATH`                   | Path where the temporary files will be saved.                          | `./temp`                           |
-| `-c`, `--cookies-location`      | `cookies_location`            | `GAMDL_COOKIES_LOCATION`            | Location of the cookies file.                                          | `./cookies.txt`                    |
-| `-w`, `--wvd-location`          | `wvd_location`                | `GAMDL_WVD_LOCATION`                | Location of the .wvd file.                                             | `./device.wvd`                     |
-| `--ffmpeg-location`             | `ffmpeg_location`             | `GAMDL_FFMPEG_LOCATION`             | Location of the FFmpeg binary.                                         | `ffmpeg`                           |
-| `--mp4box-location`             | `mp4box_location`             | `GAMDL_MP4BOX_LOCATION`             | Location of the MP4Box binary.                                         | `MP4Box`                           |
-| `--mp4decrypt-location`         | `mp4decrypt_location`         | `GAMDL_MP4DECRYPT_LOCATION`         | Location of the mp4decrypt binary.                                     | `mp4decrypt`                       |
-| `--nm3u8dlre-location`          | `nm3u8dlre_location`          | `GAMDL_NM3U8DLRE_LOCATION`          | Location of the N_m3u8DL-RE binary.                                    | `N_m3u8DL-RE`                      |
-| `--config-location`             | -                             | `GAMDL_CONFIG_LOCATION`             | Location of the config file.                                           | `<home_folder>/.gamdl/config.json` |
-| `--template-folder-album`       | `template_folder_album`       | `GAMDL_TEMPLATE_FOLDER_ALBUM`       | Template of the album folders as a format string.                      | `{album_artist}/{album}`           |
-| `--template-folder-compilation` | `template_folder_compilation` | `GAMDL_TEMPLATE_FOLDER_COMPILATION` | Template of the compilation album folders as a format string.          | `Compilations/{album}`             |
-| `--template-file-single-disc`   | `template_file_single_disc`   | `GAMDL_TEMPLATE_FILE_SINGLE_DISC`   | Template of the track files for single-disc albums as a format string. | `{track:02d} {title}`              |
-| `--template-file-multi-disc`    | `template_file_multi_disc`    | `GAMDL_TEMPLATE_FILE_MULTI_DISC`    | Template of the track files for multi-disc albums as a format string.  | `{disc}-{track:02d} {title}`       |
-| `--template-folder-music-video` | `template_folder_music_video` | `GAMDL_TEMPLATE_FOLDER_MUSIC_VIDEO` | Template of the music video folders as a format string.                | `{artist}/Unknown Album`           |
-| `--template-file-music-video`   | `template_file_music_video`   | `GAMDL_TEMPLATE_FILE_MUSIC_VIDEO`   | Template of the music video files as a format string.                  | `{title}`                          |
-| `--cover-size`                  | `cover_size`                  | `GAMDL_COVER_SIZE`                  | Size of the cover.                                                     | `1200`                             |
-| `--template-date`               | `template_date`               | `GAMDL_TEMPLATE_DATE`               | Template of the tagged date as a string with format codes.             | `%Y-%m-%dT%H:%M:%SZ`               |
-| `--cover-format`                | `cover_format`                | `GAMDL_COVER_FORMAT`                | Format of the cover.                                                   | `jpg`                              |
-| `--remux-mode`                  | `remux_mode`                  | `GAMDL_REMUX_MODE`                  | Remux mode.                                                            | `ffmpeg`                           |
-| `--download-mode`               | `download_mode`               | `GAMDL_DOWNLOAD_MODE`               | Download mode.                                                         | `ytdlp`                            |
-| `-e`, `--exclude-tags`          | `exclude_tags`                | `GAMDL_EXCLUDE_TAGS`                | List of tags to exclude from file tagging separated by commas.         | `null`                             |
-| `--truncate`                    | `truncate`                    | `GAMDL_TRUNCATE`                    | Maximum length of the file/folder names.                               | `40`                               |
-| `-l`, `--log-level`             | `log_level`                   | `GAMDL_LOG_LEVEL`                   | Log level.                                                             | `INFO`                             |
-| `--prefer-hevc`                 | `prefer_hevc`                 | `GAMDL_PREFER_HEVC`                 | Prefer HEVC over AVC when downloading music videos.                    | `false`                            |
-| `--prefer-account-language`     | `prefer_account_language`     | `GAMDL_PREFER_ACCOUNT_LANGUAGE`     | Prefer the language associated with the account rather than English.   | `false`                            |
-| `--ask-video-format`            | `ask_video_format`            | `GAMDL_ASK_VIDEO_FORMAT`            | Ask for the video format when downloading music videos.                | `false`                            |
-| `--disable-music-video-skip`    | `disable_music_video_skip`    | `GAMDL_DISABLE_MUSIC_VIDEO_SKIP`    | Don't skip downloading music videos in albums/playlists.               | `false`                            |
-| `-l`, `--lrc-only`              | `lrc_only`                    | `GAMDL_LRC_ONLY`                    | Download only the synced lyrics.                                       | `false`                            |
-| `-n`, `--no-lrc`                | `no_lrc`                      | `GAMDL_NO_LRC`                      | Don't download the synced lyrics.                                      | `false`                            |
-| `-s`, `--save-cover`            | `save_cover`                  | `GAMDL_SAVE_COVER`                  | Save cover as a separate file.                                         | `false`                            |
-| `--songs-heaac`                 | `songs_heaac`                 | `GAMDL_SONGS_HEAAC`                 | Download songs in HE-AAC 64kbps.                                       | `false`                            |
-| `-o`, `--overwrite`             | `overwrite`                   | `GAMDL_OVERWRITE`                   | Overwrite existing files.                                              | `false`                            |
-| `--print-exceptions`            | `print_exceptions`            | `GAMDL_PRINT_EXCEPTIONS`            | Print exceptions.                                                      | `false`                            |
-| `-u`, `--url-txt`               | -                             | `GAMDL_URL_TXT`                     | Read URLs as location of text files containing URLs.                   | `false`                            |
-| `-n`, `--no-config-file`        | -                             | `GAMDL_NO_CONFIG_FILE`              | Don't use the config file.                                             | `false`                            |
+You can configure gamdl by using the command line arguments, environment variables, or the config file. The config file is created automatically when you run gamdl for the first time at `~/.gamdl/config.json` on Linux and `%USERPROFILE%\.gamdl\config.json` on Windows. Environment variables are prefixed with `GAMDL_` and are the capitalized config file key for their respective option. Config file values and environment variables can be overridden using command line arguments.
+| Command line argument / Config file key                         | Description                                                            | Default value                      |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
+| `-f`, `--final-path` / `final_path`                             | Path where the downloaded files will be saved.                         | `./Apple Music`                    |
+| `-t`, `--temp-path` / `temp_path`                               | Path where the temporary files will be saved.                          | `./temp`                           |
+| `-c`, `--cookies-location` / `cookies_location`                 | Location of the cookies file.                                          | `./cookies.txt`                    |
+| `-w`, `--wvd-location` / `wvd_location`                         | Location of the .wvd file.                                             | `./device.wvd`                     |
+| `--ffmpeg-location` / `ffmpeg_location`                         | Location of the FFmpeg binary.                                         | `ffmpeg`                           |
+| `--mp4box-location` / `mp4box_location`                         | Location of the MP4Box binary.                                         | `MP4Box`                           |
+| `--mp4decrypt-location` / `mp4decrypt_location`                 | Location of the mp4decrypt binary.                                     | `mp4decrypt`                       |
+| `--nm3u8dlre-location` / `nm3u8dlre_location`                   | Location of the N_m3u8DL-RE binary.                                    | `N_m3u8DL-RE`                      |
+| `--config-location` / -                                         | Location of the config file.                                           | `<home_folder>/.gamdl/config.json` |
+| `--template-folder-album` / `template_folder_album`             | Template of the album folders as a format string.                      | `{album_artist}/{album}`           |
+| `--template-folder-compilation` / `template_folder_compilation` | Template of the compilation album folders as a format string.          | `Compilations/{album}`             |
+| `--template-file-single-disc` / `template_file_single_disc`     | Template of the track files for single-disc albums as a format string. | `{track:02d} {title}`              |
+| `--template-file-multi-disc` / `template_file_multi_disc`       | Template of the track files for multi-disc albums as a format string.  | `{disc}-{track:02d} {title}`       |
+| `--template-folder-music-video` / `template_folder_music_video` | Template of the music video folders as a format string.                | `{artist}/Unknown Album`           |
+| `--template-file-music-video` / `template_file_music_video`     | Template of the music video files as a format string.                  | `{title}`                          |
+| `--cover-size` / `cover_size`                                   | Size of the cover.                                                     | `1200`                             |
+| `--template-date` / `template_date`                             | Template of the tagged date as a string with format codes.             | `%Y-%m-%dT%H:%M:%SZ`               |
+| `--cover-format` / `cover_format`                               | Format of the cover.                                                   | `jpg`                              |
+| `--remux-mode` / `remux_mode`                                   | Remux mode.                                                            | `ffmpeg`                           |
+| `--download-mode` / `download_mode`                             | Download mode.                                                         | `ytdlp`                            |
+| `-e`, `--exclude-tags` / `exclude_tags`                         | List of tags to exclude from file tagging separated by commas.         | `null`                             |
+| `--truncate` / `truncate`                                       | Maximum length of the file/folder names.                               | `40`                               |
+| `-l`, `--log-level` / `log_level`                               | Log level.                                                             | `INFO`                             |
+| `--prefer-hevc` / `prefer_hevc`                                 | Prefer HEVC over AVC when downloading music videos.                    | `false`                            |
+| `--prefer-account-language` / `prefer_account_language`         | Prefer the language associated with the account rather than English.   | `false`                            |
+| `--ask-video-format` / `ask_video_format`                       | Ask for the video format when downloading music videos.                | `false`                            |
+| `--disable-music-video-skip` / `disable_music_video_skip`       | Don't skip downloading music videos in albums/playlists.               | `false`                            |
+| `-l`, `--lrc-only` / `lrc_only`                                 | Download only the synced lyrics.                                       | `false`                            |
+| `-n`, `--no-lrc` / `no_lrc`                                     | Don't download the synced lyrics.                                      | `false`                            |
+| `-s`, `--save-cover` / `save_cover`                             | Save cover as a separate file.                                         | `false`                            |
+| `--songs-heaac` / `songs_heaac`                                 | Download songs in HE-AAC 64kbps.                                       | `false`                            |
+| `-o`, `--overwrite` / `overwrite`                               | Overwrite existing files.                                              | `false`                            |
+| `--print-exceptions` / `print_exceptions`                       | Print exceptions.                                                      | `false`                            |
+| `-u`, `--url-txt` / -                                           | Read URLs as location of text files containing URLs.                   | `false`                            |
+| `-n`, `--no-config-file` / -                                    | Don't use the config file.                                             | `false`                            |
 
 
 ### Tags variables

--- a/gamdl/cli.py
+++ b/gamdl/cli.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import os
 import json
 import logging
 from pathlib import Path
 
 import click
-
 from . import __version__
 from .constants import *
 from .downloader import Downloader
@@ -13,6 +13,9 @@ from .downloader import Downloader
 
 def write_default_config_file(ctx: click.Context) -> None:
     ctx.params["config_location"].parent.mkdir(parents=True, exist_ok=True)
+    for param in (param for param in ctx.command.params) :
+        if callable(param.default) and param.default.__name__ == '<lambda>':
+            param.default = param.default()
     config_file = {
         param.name: param.default
         for param in ctx.command.params
@@ -52,210 +55,222 @@ def no_config_callback(
     "--final-path",
     "-f",
     type=Path,
-    default="./Apple Music",
+    default=lambda: os.environ.get("GAMDL_FINAL_PATH", "./Apple Music"),
     help="Path where the downloaded files will be saved.",
 )
 @click.option(
     "--temp-path",
     "-t",
     type=Path,
-    default="./temp",
+    default=lambda: os.environ.get("GAMDL_TEMP_PATH", "./temp"),
     help="Path where the temporary files will be saved.",
 )
 @click.option(
     "--cookies-location",
     "-c",
     type=Path,
-    default="./cookies.txt",
+    default=lambda: os.environ.get("GAMDL_COOKIES_LOCATION", "./cookies.txt"),
     help="Location of the cookies file.",
 )
 @click.option(
     "--wvd-location",
     "-w",
     type=Path,
-    default="./device.wvd",
+    default=lambda: os.environ.get("GAMDL_WVD_LOCATION", "./device.wvd"),
     help="Location of the .wvd file.",
 )
 @click.option(
     "--ffmpeg-location",
     type=str,
-    default="ffmpeg",
+    default=lambda: os.environ.get("GAMDL_FFMPEG_LOCATION", "ffmpeg"),
     help="Location of the FFmpeg binary.",
 )
 @click.option(
     "--mp4box-location",
     type=str,
-    default="MP4Box",
+    default=lambda: os.environ.get("GAMDL_MP4BOX_LOCATION", "MP4Box"),
     help="Location of the MP4Box binary.",
 )
 @click.option(
     "--mp4decrypt-location",
     type=str,
-    default="mp4decrypt",
+    default=lambda: os.environ.get("GAMDL_MP4DECRYPT_LOCATION", "mp4decrypt"),
     help="Location of the mp4decrypt binary.",
 )
 @click.option(
     "--nm3u8dlre-location",
     type=str,
-    default="N_m3u8DL-RE",
+    default=lambda: os.environ.get("GAMDL_NM3U8DLRE_LOCATION", "N_m3u8DL-RE"),
     help="Location of the N_m3u8DL-RE binary.",
 )
 @click.option(
     "--config-location",
     type=Path,
-    default=Path.home() / ".gamdl" / "config.json",
+    default=lambda: os.environ.get("GAMDL_CONFIG_LOCATION", Path.home() / ".gamdl" / "config.json"),
     help="Location of the config file.",
 )
 @click.option(
     "--template-folder-album",
     type=str,
-    default="{album_artist}/{album}",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_FOLDER_ALBUM", "{album_artist}/{album}"),
     help="Template of the album folders as a format string.",
 )
 @click.option(
     "--template-folder-compilation",
     type=str,
-    default="Compilations/{album}",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_FOLDER_COMPILATION", "Compilations/{album}"),
     help="Template of the compilation album folders as a format string.",
 )
 @click.option(
     "--template-file-single-disc",
     type=str,
-    default="{track:02d} {title}",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_FILE_SINGLE_DISC", "{track:02d} {title}"),
     help="Template of the track files for single-disc albums as a format string.",
 )
 @click.option(
     "--template-file-multi-disc",
     type=str,
-    default="{disc}-{track:02d} {title}",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_FILE_MULTI_DISC", "{disc}-{track:02d} {title}"),
     help="Template of the track files for multi-disc albums as a format string.",
 )
 @click.option(
     "--template-folder-music-video",
     type=str,
-    default="{artist}/Unknown Album",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_FOLDER_MUSIC_VIDEO", "{artist}/Unknown Album"),
     help="Template of the music video folders as a format string.",
 )
 @click.option(
     "--template-file-music-video",
     type=str,
-    default="{title}",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_FILE_MUSIC_VIDEO", "{title}"),
     help="Template of the music video files as a format string.",
 )
 @click.option(
     "--template-date",
     type=str,
-    default="%Y-%m-%dT%H:%M:%SZ",
+    default=lambda: os.environ.get("GAMDL_TEMPLATE_DATE", "%Y-%m-%dT%H:%M:%SZ"),
     help="Template of the tagged date as a string with format codes.",
 )
 @click.option(
     "--cover-size",
     type=int,
-    default=1200,
+    default=lambda: os.environ.get("GAMDL_COVER_SIZE", 1200),
     help="Size of the cover.",
 )
 @click.option(
     "--cover-format",
     type=click.Choice(["jpg", "png"]),
-    default="jpg",
+    default=lambda: os.environ.get("GAMDL_COVER_FORMAT", "jpg"),
     help="Format of the cover.",
 )
 @click.option(
     "--remux-mode",
     type=click.Choice(["ffmpeg", "mp4box"]),
-    default="ffmpeg",
+    default=lambda: os.environ.get("GAMDL_REMUX_MODE", "ffmpeg"),
     help="Remux mode.",
 )
 @click.option(
     "--download-mode",
     type=click.Choice(["ytdlp", "nm3u8dlre"]),
-    default="ytdlp",
+    default=lambda: os.environ.get("GAMDL_DOWNLOAD_MODE", "ytdlp"),
     help="Download mode.",
 )
 @click.option(
     "--exclude-tags",
     "-e",
     type=str,
-    default=None,
+    default=lambda: os.environ.get("GAMDL_EXCLUDE_TAGS", None),
     help="List of tags to exclude from file tagging separated by commas.",
 )
 @click.option(
     "--truncate",
     type=int,
-    default=40,
+    default=lambda: os.environ.get("GAMDL_TRUNCATE", 40),
     help="Maximum length of the file/folder names.",
 )
 @click.option(
     "--log-level",
     "-l",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
-    default="INFO",
+    default=lambda: os.environ.get("GAMDL_LOG_LEVEL", "INFO"),
     help="Log level.",
 )
 @click.option(
     "--prefer-hevc",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_PREFER_HEVC", "False").lower() in ('true', '1', 'yes') else False,
     help="Prefer HEVC over AVC when downloading music videos.",
 )
 @click.option(
     "--prefer-account-language",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_PREFER_ACCOUNT_LANGUAGE", "False").lower() in ('true', '1', 'yes') else False,
     help="Prefer the language associated with the account rather than English."
 )
 @click.option(
     "--ask-video-format",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_ASK_VIDEO_FORMAT", "False").lower() in ('true', '1', 'yes') else False,
     help="Ask for the video format when downloading music videos.",
 )
 @click.option(
     "--disable-music-video-skip",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_DISABLE_MUSIC_VIDEO_SKIP", "False").lower() in ('true', '1', 'yes') else False,
     help="Don't skip downloading music videos in albums/playlists.",
 )
 @click.option(
     "--lrc-only",
     "-l",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_LRC_ONLY", "False").lower() in ('true', '1', 'yes') else False,
     help="Download only the synced lyrics.",
 )
 @click.option(
     "--no-lrc",
     "-n",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_NO_LRC", "False").lower() in ('true', '1', 'yes') else False,
     help="Don't download the synced lyrics.",
 )
 @click.option(
     "--save-cover",
     "-s",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_SAVE_COVER", "False").lower() in ('true', '1', 'yes') else False,
     help="Save cover as a separate file.",
 )
 @click.option(
     "--songs-heaac",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_SONGS_HEAAC", "False").lower() in ('true', '1', 'yes') else False,
     help="Download songs in HE-AAC 64kbps.",
 )
 @click.option(
     "--overwrite",
     "-o",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_OVERWRITE", "False").lower() in ('true', '1', 'yes') else False,
     help="Overwrite existing files.",
 )
 @click.option(
     "--print-exceptions",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_PRINT_EXCEPTIONS", "False").lower() in ('true', '1', 'yes') else False,
     help="Print exceptions.",
 )
 @click.option(
     "--url-txt",
     "-u",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_URL_TXT", "False").lower() in ('true', '1', 'yes') else False,
     help="Read URLs as location of text files containing URLs.",
 )
 @click.option(
     "--no-config-file",
     "-n",
     is_flag=True,
+    default=lambda: True if os.environ.get("GAMDL_NO_CONFIG_FILE", "False").lower() in ('true', '1', 'yes') else False,
     callback=no_config_callback,
     help="Don't use the config file.",
 )

--- a/gamdl/cli.py
+++ b/gamdl/cli.py
@@ -13,9 +13,6 @@ from .downloader import Downloader
 
 def write_default_config_file(ctx: click.Context) -> None:
     ctx.params["config_location"].parent.mkdir(parents=True, exist_ok=True)
-    for param in (param for param in ctx.command.params) :
-        if callable(param.default) and param.default.__name__ == '<lambda>':
-            param.default = param.default()
     config_file = {
         param.name: param.default
         for param in ctx.command.params


### PR DESCRIPTION
Thank you so much for your work on this project! I love it and use it every day.

In an effort to make execution in a docker container simpler and easier, I've added support for configuration via environment variables that can be set by a container orchestrator often more conveniently than command-line options can be set. My current docker container for this app hacks environment support on top of the current release, but I thought adding it to the source would be cleaner, and make it simpler to define a dockerfile for. 

I'd love to go ahead and define a Docker container for this project as well, but I wanted to offer this change up first to get your feedback before I start on the dockerfile.