### PR TITLE
Fix handling of 'Favorite Songs' playlist

### DIFF
--- a/gamdl/downloader.py
+++ b/gamdl/downloader.py
@@ -255,7 +255,7 @@ class Downloader:
         playlist_track: int,
     ) -> dict:
         tags = {
-            "playlist_artist": playlist_attributes["curatorName"],
+            "playlist_artist": playlist_attributes.get("curatorName", "Apple Music"),
             "playlist_id": playlist_attributes["playParams"]["id"],
             "playlist_title": playlist_attributes["name"],
             "playlist_track": playlist_track,


### PR DESCRIPTION
## Description
This PR fixes a crash that occurs when downloading the 'Favorite Songs' playlist. The issue arises because this automatically generated playlist lacks the `curatorName` attribute, which was previously accessed directly.

## Changes
- Modified `get_playlist_tags()` to handle missing `curatorName` attribute
- Set default curator to 'Apple Music' for system playlists
- Improved error handling for playlist metadata

## Code Changes
```python
def get_playlist_tags(self, playlist_attributes: dict, playlist_track: int) -> dict:
    tags = {
        "playlist_artist": playlist_attributes.get("curatorName", "Apple Music"),
        "playlist_id": playlist_attributes["playParams"]["id"],
        "playlist_title": playlist_attributes["name"],
        "playlist_track": playlist_track,
    }
    return tags
```

## Testing
- [x] Tested with 'Favorite Songs' playlist
- [x] Verified compatibility with regular playlists
- [x] Ensured playlist metadata is correctly saved