### PR TITLE
Separate output streams into stdout and stderr

### DIFF
--- a/gamdl/cli.py
+++ b/gamdl/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import sys
 from enum import Enum
 from pathlib import Path
 
@@ -373,9 +374,15 @@ def main(
 ):
     colorama.just_fix_windows_console()
     logger.setLevel(log_level)
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(CustomLoggerFormatter())
-    logger.addHandler(stream_handler)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.DEBUG)
+    stdout_handler.addFilter(lambda record: record.levelno < logging.WARNING)
+    stdout_handler.setFormatter(CustomLoggerFormatter())
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(CustomLoggerFormatter())
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
     logger.info("Starting Gamdl")
     cookies_path = prompt_path(True, cookies_path, "Cookies file")
     apple_music_api = AppleMusicApi.from_netscape_cookies(


### PR DESCRIPTION
Prior to this change, _all_ log messages were output to `stderr` by a single `StreamHandler`. This PR creates two separate handlers which route INFO and below to `stdout` and WARNING and above to `stderr`. This improves flexibility in script applications and when redirecting/piping gamdl output.

- `stdout_handler`
    - Stream: `stdout`
    - Log levels: DEBUG, INFO
- `stderr_handler`
    - Stream: `stderr`
    - Log levels: WARNING, ERROR, CRITICAL

## Example - gamdl output redirection

```
gamdl "https://..." > out.txt 2> err.txt
gamdl "https://..." &> all.txt
```

### Before

out.txt:
```
```

err.txt:
```
[INFO     18:07:36] Starting Gamdl
[WARNING  18:07:37] mp4decrypt not found at "mp4decrypt", music videos will not be downloaded
[INFO     18:07:37] (URL 1/1) Checking "https://..."
[INFO     18:07:37] (Track 1/1 from URL 1/1) Downloading "C-Jam Blues"
[WARNING  18:07:37] (Track 1/1 from URL 1/1) Song already exists at "...", skipping
[INFO     18:07:37] Done (0 error(s))
```

all.txt:
```
[INFO     18:07:36] Starting Gamdl
[WARNING  18:07:37] mp4decrypt not found at "mp4decrypt", music videos will not be downloaded
[INFO     18:07:37] (URL 1/1) Checking "https://..."
[INFO     18:07:37] (Track 1/1 from URL 1/1) Downloading "C-Jam Blues"
[WARNING  18:07:37] (Track 1/1 from URL 1/1) Song already exists at "...", skipping
[INFO     18:07:37] Done (0 error(s))
```

### After

out.txt:
```
[INFO     18:07:36] Starting Gamdl
[INFO     18:07:37] (URL 1/1) Checking "https://..."
[INFO     18:07:37] (Track 1/1 from URL 1/1) Downloading "C-Jam Blues"
[INFO     18:07:37] Done (0 error(s))
```

err.txt:
```
[WARNING  18:07:37] mp4decrypt not found at "mp4decrypt", music videos will not be downloaded
[WARNING  18:07:37] (Track 1/1 from URL 1/1) Song already exists at "...", skipping
```

all.txt:
```
[INFO     18:07:36] Starting Gamdl
[WARNING  18:07:37] mp4decrypt not found at "mp4decrypt", music videos will not be downloaded
[INFO     18:07:37] (URL 1/1) Checking "https://..."
[INFO     18:07:37] (Track 1/1 from URL 1/1) Downloading "C-Jam Blues"
[WARNING  18:07:37] (Track 1/1 from URL 1/1) Song already exists at "...", skipping
[INFO     18:07:37] Done (0 error(s))
```