### PR TITLE
Parse variable-length playlist IDs.

### DIFF
--- a/gamdl/downloader.py
+++ b/gamdl/downloader.py
@@ -48,7 +48,7 @@ class Downloader:
         r"/(?P<storefront>[a-z]{2})"
         r"/(?P<type>artist|album|playlist|song|music-video|post)"
         r"(?:/(?P<slug>[^\s/]+))?"
-        r"/(?P<id>[0-9]+|pl\.[0-9a-z]{32}|pl\.u-[a-zA-Z0-9]{10})"
+        r"/(?P<id>[0-9]+|pl\.[0-9a-z]{32}|pl\.u-[a-zA-Z0-9]+)"
         r"(?:\?i=(?P<sub_id>[0-9]+))?"
         r")|("
         r"(?:/(?P<library_storefront>[a-z]{2}))?"


### PR DESCRIPTION
I'm sorry!  I just came across another playlist ID in the `pl.u-` format with 14 characters after the dash.  This should be a more forgiving way to parse.  (If you know the range of lengths, you could definitely constrain it, but unfortunately I don't know what lengths Apple might generate.)

Thanks again for all your work on this!