### PR TITLE
feat: download entire library

### DIFF
--- a/gamdl/api/apple_music_api.py
+++ b/gamdl/api/apple_music_api.py
@@ -332,6 +332,29 @@ class AppleMusicApi:
 
         return playlist
 
+    async def get_library_songs(
+        self,
+        limit: int = 100,
+    ) -> list[dict]:
+        songs: list[dict] = []
+        next_url = f"/v1/me/library/songs?limit={limit}"
+
+        while next_url:
+            response = await self.client.get(f"{AMP_API_URL}{next_url}",params=None)
+            raise_for_status(response)
+
+            library_page = safe_json(response)
+
+            if "data" not in library_page:
+                raise Exception("Error getting library songs:", response.text)
+
+            songs.extend(library_page["data"])
+            next_url = library_page.get("next")
+
+        logger.debug(f"Library songs fetched: {len(songs)}")
+
+        return songs
+
     async def get_search_results(
         self,
         term: str,

--- a/gamdl/cli/cli.py
+++ b/gamdl/cli/cli.py
@@ -553,30 +553,40 @@ async def main(
 
     error_count = 0
     for url_index, url in enumerate(urls, 1):
+        url_value = url.strip()
         url_progress = click.style(f"[URL {url_index}/{len(urls)}]", dim=True)
-        logger.info(url_progress + f' Processing "{url}"')
+        logger.info(url_progress + f' Processing "{url_value}"')
         download_queue = None
         try:
-            url_info = downloader.get_url_info(url)
-            if not url_info:
-                logger.warning(
-                    url_progress + f' Could not parse "{url}", skipping.',
-                )
-                continue
+            if url_value.lower() == "library":
+                download_queue = await downloader.get_download_queue_library()
+                if not download_queue:
+                    logger.warning(
+                        url_progress
+                        + ' No downloadable media found for "library", skipping.',
+                    )
+                    continue
+            else:
+                url_info = downloader.get_url_info(url_value)
+                if not url_info:
+                    logger.warning(
+                        url_progress + f' Could not parse "{url_value}", skipping.',
+                    )
+                    continue
 
-            download_queue = await downloader.get_download_queue(url_info)
-            if not download_queue:
-                logger.warning(
-                    url_progress
-                    + f' No downloadable media found for "{url}", skipping.',
-                )
-                continue
+                download_queue = await downloader.get_download_queue(url_info)
+                if not download_queue:
+                    logger.warning(
+                        url_progress
+                        + f' No downloadable media found for "{url_value}", skipping.',
+                    )
+                    continue
         except KeyboardInterrupt:
             exit(1)
         except Exception as e:
             error_count += 1
             logger.error(
-                url_progress + f' Error processing "{url}"',
+                url_progress + f' Error processing "{url_value}"',
                 exc_info=not no_exceptions,
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ wheels = [
 
 [[package]]
 name = "gamdl"
-version = "2.7"
+version = "2.7.5"
 source = { virtual = "." }
 dependencies = [
     { name = "async-lru" },


### PR DESCRIPTION
**Usage:**
Pass library as the first argument to download the entire library, `gamdl library`.