### PR TITLE
Add CLI and config options to auto-download artist albums and music videos

### DIFF
--- a/gamdl/cli/cli.py
+++ b/gamdl/cli/cli.py
@@ -9,24 +9,14 @@ from dataclass_click import dataclass_click
 
 from .. import __version__
 from ..api import AppleMusicApi, ItunesApi
-from ..downloader import (
-    AppleMusicBaseDownloader,
-    AppleMusicDownloader,
-    AppleMusicMusicVideoDownloader,
-    AppleMusicSongDownloader,
-    AppleMusicUploadedVideoDownloader,
-    DownloadItem,
-    DownloadMode,
-    GamdlError,
-    RemuxMode,
-)
-from ..interface import (
-    AppleMusicInterface,
-    AppleMusicMusicVideoInterface,
-    AppleMusicSongInterface,
-    AppleMusicUploadedVideoInterface,
-    SongCodec,
-)
+from ..downloader import (AppleMusicBaseDownloader, AppleMusicDownloader,
+                          AppleMusicMusicVideoDownloader,
+                          AppleMusicSongDownloader,
+                          AppleMusicUploadedVideoDownloader, DownloadItem,
+                          DownloadMode, GamdlError, RemuxMode)
+from ..interface import (AppleMusicInterface, AppleMusicMusicVideoInterface,
+                         AppleMusicSongInterface,
+                         AppleMusicUploadedVideoInterface, SongCodec)
 from .cli_config import CliConfig
 from .config_file import ConfigFile
 from .constants import X_NOT_IN_PATH
@@ -161,6 +151,8 @@ async def main(config: CliConfig):
         song_downloader=song_downloader,
         music_video_downloader=music_video_downloader,
         uploaded_video_downloader=uploaded_video_downloader,
+        download_artist_albums=config.download_artist_albums,
+        download_artist_music_videos=config.download_artist_music_videos,
     )
 
     if not config.synced_lyrics_only:

--- a/gamdl/cli/cli_config.py
+++ b/gamdl/cli/cli_config.py
@@ -7,23 +7,13 @@ import click
 from dataclass_click import argument, option
 
 from ..api import AppleMusicApi
-from ..downloader import (
-    AppleMusicBaseDownloader,
-    AppleMusicMusicVideoDownloader,
-    AppleMusicSongDownloader,
-    AppleMusicUploadedVideoDownloader,
-    DownloadMode,
-    RemuxFormatMusicVideo,
-    RemuxMode,
-)
-from ..interface import (
-    CoverFormat,
-    MusicVideoCodec,
-    MusicVideoResolution,
-    SongCodec,
-    SyncedLyricsFormat,
-    UploadedVideoQuality,
-)
+from ..downloader import (AppleMusicBaseDownloader,
+                          AppleMusicMusicVideoDownloader,
+                          AppleMusicSongDownloader,
+                          AppleMusicUploadedVideoDownloader, DownloadMode,
+                          RemuxFormatMusicVideo, RemuxMode)
+from ..interface import (CoverFormat, MusicVideoCodec, MusicVideoResolution,
+                         SongCodec, SyncedLyricsFormat, UploadedVideoQuality)
 from .utils import Csv
 
 api_from_cookies_sig = inspect.signature(AppleMusicApi.create_from_netscape_cookies)
@@ -465,6 +455,22 @@ class CliConfig:
             help="Post video quality",
             default=uploaded_video_downloader_sig.parameters["quality"].default,
             type=UploadedVideoQuality,
+        ),
+    ]
+    download_artist_albums: Annotated[
+        bool,
+        option(
+            "--download-artist-albums",
+            help="Download all albums from artist",
+            is_flag=True,
+        ),
+    ]
+    download_artist_music_videos: Annotated[
+        bool,
+        option(
+            "--download-artist-music-videos",
+            help="Download all music videos from artist",
+            is_flag=True,
         ),
     ]
     no_config_file: Annotated[


### PR DESCRIPTION
This PR adds two new CLI flags:

--download-artist-albums

--download-artist-music-videos

When used with an artist URL, these flags skip the interactive media-type prompt and automatically download all albums and/or music videos. If neither flag is provided, existing interactive behavior remains unchanged.

Implementation:

1)Added options in cli_config.py
2)Passed flags through cli.py
3)Updated AppleMusicDownloader to conditionally bypass prompts
4)Preserved backward compatibility with default values set to False