### PR TITLE
fix: add support for Apple Music Classical URLs

### DIFF
--- a/gamdl/downloader/constants.py
+++ b/gamdl/downloader/constants.py
@@ -13,7 +13,7 @@ UPLOADED_VIDEO_MEDIA_TYPE = {"post", "uploaded-videos"}
 PLAYLIST_MEDIA_TYPE = {"playlist", "playlists", "library-playlists"}
 
 VALID_URL_PATTERN = re.compile(
-    r"https://music\.apple\.com"
+    r"https://(?:classical\.)?music\.apple\.com"
     r"(?:"
     r"/(?P<storefront>[a-z]{2})"
     r"/(?P<type>artist|album|playlist|song|music-video|post)"


### PR DESCRIPTION
## Changes
Updates the URL validation regex to support Apple Music Classical URLs (`https://classical.music.apple.com/...`).

## Details
- Modified `VALID_URL_PATTERN` in `gamdl/downloader/constants.py`
- Added optional `classical.` subdomain using `(?:classical\.)?` pattern
- Maintains backward compatibility with standard Apple Music URLs

## Testing
Supports URLs like:
- `https://classical.music.apple.com/us/album/1452516762`
- `https://music.apple.com/us/album/1452516762` (existing functionality)