### PR TITLE
Fix KeyError during artist download pagination

### DIFF
--- a/gamdl/downloader/downloader.py
+++ b/gamdl/downloader/downloader.py
@@ -174,14 +174,10 @@ class AppleMusicDownloader:
             artist_auto_select = self.artist_auto_select
 
         relation_key, type_key = artist_auto_select.path_key
-        artist_metadata[relation_key][type_key]["data"].extend(
-            [
-                extended_data
-                async for extended_data in self.interface.apple_music_api.extend_api_data(
-                    artist_metadata[relation_key][type_key],
-                )
-            ]
-        )
+        async for extended_data in self.interface.apple_music_api.extend_api_data(
+            artist_metadata[relation_key][type_key],
+        ):
+            artist_metadata[relation_key][type_key]["data"].extend(extended_data["data"])
 
         selected_items = artist_metadata[relation_key][type_key]["data"]
         select_all = self.artist_auto_select is not None


### PR DESCRIPTION
# Pull Request: Fix KeyError during artist download pagination

## Problem
When using artist download options like `--artist-auto-select all-albums` on artists with a large number of releases (triggering the API pagination logic), the downloader would crash with a `KeyError: 'id'`.

This was caused by the code incorrectly extending the [data](file:///Users/leo/Documents/code/github/gamdl-web/gamdl/api/apple_music_api.py#373-392) list with the entire response dictionary (which contains [data](file:///Users/leo/Documents/code/github/gamdl-web/gamdl/api/apple_music_api.py#373-392) and `next` keys) instead of extracting and extending with the nested [data](file:///Users/leo/Documents/code/github/gamdl-web/gamdl/api/apple_music_api.py#373-392) list. When the subsequent loop tried to read `album_metadata["id"]` from that dictionary object, it failed.

## Solution
Replaced the erroneous list comprehension with an explicit `async for` loop that correctly extends the results with `extended_data["data"]`. 

```python
# Before (Buggy)
artist_metadata[relation_key][type_key]["data"].extend(
    [
        extended_data
        async for extended_data in self.interface.apple_music_api.extend_api_data(...)
    ]
)

# After (Fixed)
async for extended_data in self.interface.apple_music_api.extend_api_data(...):
    artist_metadata[relation_key][type_key]["data"].extend(extended_data["data"])
```

This change ensures only album-like objects are in the list and makes the logic consistent with similar pagination handling found elsewhere in the codebase (e.g., in [get_collection_download_items](file:///Users/leo/Documents/code/github/gamdl-web/gamdl/downloader/downloader.py#126-150)).

## Testing
Verified by running `gamdl` on an artist with a large number of singles/albums (e.g., Megan Nicole).
- **Before fix**: Process crashed with `KeyError: 'id'` once pagination was triggered.
- **After fix**: Successfully fetched all pages and queued all tracks for download.
