### PR TITLE
Add syllable_lyrics endpoint.

### DIFF
--- a/gamdl/api/apple_music_api.py
+++ b/gamdl/api/apple_music_api.py
@@ -236,6 +236,14 @@ class AppleMusicApi:
 
         return song
 
+    async def get_syllable_lyrics(self, song_id: str) -> dict | None:
+        syllable_lyrics = await self._amp_request(
+            f"/v1/catalog/{self.storefront}/songs/{song_id}/syllable-lyrics",
+        )
+        logger.debug(f"Syllable lyrics: {syllable_lyrics}")
+
+        return syllable_lyrics
+
     async def get_music_video(
         self,
         music_video_id: str,

--- a/gamdl/api/apple_music_api.py
+++ b/gamdl/api/apple_music_api.py
@@ -223,7 +223,7 @@ class AppleMusicApi:
         self,
         song_id: str,
         extend: str = "extendedAssetUrls",
-        include: str = "lyrics,albums",
+        include: str = "syllable-lyrics,albums",
     ) -> dict | None:
         song = await self._amp_request(
             f"/v1/catalog/{self.storefront}/songs/{song_id}",
@@ -235,14 +235,6 @@ class AppleMusicApi:
         logger.debug(f"Song: {song}")
 
         return song
-
-    async def get_syllable_lyrics(self, song_id: str) -> dict | None:
-        syllable_lyrics = await self._amp_request(
-            f"/v1/catalog/{self.storefront}/songs/{song_id}/syllable-lyrics",
-        )
-        logger.debug(f"Syllable lyrics: {syllable_lyrics}")
-
-        return syllable_lyrics
 
     async def get_music_video(
         self,

--- a/gamdl/downloader/downloader_song.py
+++ b/gamdl/downloader/downloader_song.py
@@ -49,7 +49,7 @@ class AppleMusicSongDownloader(AppleMusicBaseDownloader):
         webplayback = await self.interface.apple_music_api.get_webplayback(song_id)
         download_item.media_tags = await self.interface.get_tags(
             webplayback,
-            download_item.lyrics.unsynced if download_item.lyrics else None,
+            (download_item.lyrics.synced if download_item.lyrics and download_item.lyrics.synced else download_item.lyrics.unsynced) if download_item.lyrics else None,
             self.use_album_date,
         )
         if self.fetch_extra_tags:

--- a/gamdl/interface/interface_song.py
+++ b/gamdl/interface/interface_song.py
@@ -54,25 +54,48 @@ class AppleMusicSongInterface(AppleMusicInterface):
                 )
             )["data"][0]
 
-        if (
-            "lyrics" in song_metadata["relationships"]
-            and "data" in song_metadata["relationships"]["lyrics"]
-            and len(song_metadata["relationships"]["lyrics"]["data"]) > 0
-            and "attributes" in song_metadata["relationships"]["lyrics"]["data"][0]
-            and song_metadata["relationships"]["lyrics"]["data"][0]["attributes"].get(
-                "ttml"
+        lyrics_ttml = None
+        try:
+            lyrics_response = await self.apple_music_api.get_syllable_lyrics(
+                self.get_media_id_of_library_media(song_metadata)
             )
-            is not None
-        ):
-            lyrics = self._get_lyrics(
-                song_metadata["relationships"]["lyrics"]["data"][0]["attributes"][
-                    "ttml"
-                ],
-                synced_lyrics_format,
+            if (
+                lyrics_response
+                and "data" in lyrics_response
+                and len(lyrics_response["data"]) > 0
+                and "attributes" in lyrics_response["data"][0]
+            ):
+                lyrics_ttml = lyrics_response["data"][0]["attributes"].get("ttml")
+        except Exception as exc:  # preserve existing behavior if endpoint fails
+            logger.debug(
+                f"Failed to fetch syllable lyrics endpoint, falling back to metadata lyrics: {exc}"
             )
-            logging.debug(f"Lyrics: {lyrics}")
 
-            return lyrics
+        if lyrics_ttml is None:
+            if (
+                "lyrics" in song_metadata["relationships"]
+                and "data" in song_metadata["relationships"]["lyrics"]
+                and len(song_metadata["relationships"]["lyrics"]["data"]) > 0
+                and "attributes" in song_metadata["relationships"]["lyrics"]["data"][0]
+                and song_metadata["relationships"]["lyrics"]["data"][0]["attributes"].get(
+                    "ttml"
+                )
+                is not None
+            ):
+                lyrics_ttml = song_metadata["relationships"]["lyrics"]["data"][0]["attributes"].get(
+                    "ttml"
+                )
+
+        if lyrics_ttml is None:
+            return None
+
+        lyrics = self._get_lyrics(
+            lyrics_ttml,
+            synced_lyrics_format,
+        )
+        logging.debug(f"Lyrics: {lyrics}")
+
+        return lyrics
 
     def _get_lyrics(
         self,

--- a/gamdl/interface/interface_song.py
+++ b/gamdl/interface/interface_song.py
@@ -45,7 +45,8 @@ class AppleMusicSongInterface(AppleMusicInterface):
 
         if (
             "relationships" not in song_metadata
-            or "lyrics" not in song_metadata["relationships"]
+            or ("lyrics" not in song_metadata["relationships"] 
+                and "syllable-lyrics" not in song_metadata["relationships"])
         ):
             song_metadata = (
                 await self.apple_music_api.get_song(
@@ -53,48 +54,42 @@ class AppleMusicSongInterface(AppleMusicInterface):
                 )
             )["data"][0]
 
-        lyrics_ttml = None
-        try:
-            lyrics_response = await self.apple_music_api.get_syllable_lyrics(
-                self.get_media_id_of_library_media(song_metadata)
+        # Prioritize syllable-lyrics (word-level timing) over regular lyrics
+        lyrics_data = None
+        
+        if (
+            "syllable-lyrics" in song_metadata["relationships"]
+            and "data" in song_metadata["relationships"]["syllable-lyrics"]
+            and len(song_metadata["relationships"]["syllable-lyrics"]["data"]) > 0
+            and "attributes" in song_metadata["relationships"]["syllable-lyrics"]["data"][0]
+            and song_metadata["relationships"]["syllable-lyrics"]["data"][0]["attributes"].get(
+                "ttml"
             )
-            if (
-                lyrics_response
-                and "data" in lyrics_response
-                and len(lyrics_response["data"]) > 0
-                and "attributes" in lyrics_response["data"][0]
-            ):
-                lyrics_ttml = lyrics_response["data"][0]["attributes"].get("ttml")
-        except Exception as exc:  # preserve existing behavior if endpoint fails
-            logger.debug(
-                f"Failed to fetch syllable lyrics endpoint, falling back to metadata lyrics: {exc}"
+            is not None
+        ):
+            lyrics_data = song_metadata["relationships"]["syllable-lyrics"]["data"][0]["attributes"]["ttml"]
+        elif (
+            "lyrics" in song_metadata["relationships"]
+            and "data" in song_metadata["relationships"]["lyrics"]
+            and len(song_metadata["relationships"]["lyrics"]["data"]) > 0
+            and "attributes" in song_metadata["relationships"]["lyrics"]["data"][0]
+            and song_metadata["relationships"]["lyrics"]["data"][0]["attributes"].get(
+                "ttml"
             )
+            is not None
+        ):
+            lyrics_data = song_metadata["relationships"]["lyrics"]["data"][0]["attributes"]["ttml"]
 
-        if lyrics_ttml is None:
-            if (
-                "lyrics" in song_metadata["relationships"]
-                and "data" in song_metadata["relationships"]["lyrics"]
-                and len(song_metadata["relationships"]["lyrics"]["data"]) > 0
-                and "attributes" in song_metadata["relationships"]["lyrics"]["data"][0]
-                and song_metadata["relationships"]["lyrics"]["data"][0]["attributes"].get(
-                    "ttml"
-                )
-                is not None
-            ):
-                lyrics_ttml = song_metadata["relationships"]["lyrics"]["data"][0]["attributes"].get(
-                    "ttml"
-                )
+        if lyrics_data is not None:
+            lyrics = self._get_lyrics(
+                lyrics_data,
+                synced_lyrics_format,
+            )
+            logging.debug(f"Lyrics: {lyrics}")
 
-        if lyrics_ttml is None:
-            return None
-
-        lyrics = self._get_lyrics(
-            lyrics_ttml,
-            synced_lyrics_format,
-        )
-        logging.debug(f"Lyrics: {lyrics}")
-
-        return lyrics
+            return lyrics
+        
+        return None
 
     def _get_lyrics(
         self,

--- a/gamdl/interface/interface_song.py
+++ b/gamdl/interface/interface_song.py
@@ -5,7 +5,6 @@ import io
 import json
 import logging
 import re
-from xml.dom import minidom
 from xml.etree import ElementTree
 
 import m3u8
@@ -102,6 +101,9 @@ class AppleMusicSongInterface(AppleMusicInterface):
         lyrics_ttml: str,
         synced_lyrics_format: SyncedLyricsFormat,
     ) -> Lyrics:
+        ElementTree.register_namespace("", "http://www.w3.org/ns/ttml")
+        ElementTree.register_namespace("itunes", "http://music.apple.com/lyric-ttml-internal")
+        ElementTree.register_namespace("ttm", "http://www.w3.org/ns/ttml#metadata")
         lyrics_ttml_et = ElementTree.fromstring(lyrics_ttml)
         unsynced_lyrics = []
         synced_lyrics = []
@@ -124,9 +126,19 @@ class AppleMusicSongInterface(AppleMusicInterface):
 
                     if synced_lyrics_format == SyncedLyricsFormat.TTML:
                         if not synced_lyrics:
-                            synced_lyrics.append(
-                                minidom.parseString(lyrics_ttml).toprettyxml()
+                            for elem in lyrics_ttml_et.iter():
+                                if elem.tail:
+                                    current_text = elem.text or ""
+                                    elem.text = current_text + elem.tail
+                                    elem.tail = None
+                                
+                            ElementTree.indent(lyrics_ttml_et, space="  ")
+                            pretty_xml = ElementTree.tostring(
+                                lyrics_ttml_et, 
+                                encoding="unicode",
                             )
+                            synced_lyrics.append(pretty_xml)
+                        
                         continue
 
                     index += 1


### PR DESCRIPTION
This adds the syllable_lyrics endpoint for ttml and prefers those over the lyrics in the metadata, if available. It falls back to the metadata lyrics if they are not.