### PR TITLE
fix (song): `--song-codec-priority` not using fallback codecs

### DIFF
--- a/gamdl/interface/song.py
+++ b/gamdl/interface/song.py
@@ -251,11 +251,19 @@ class AppleMusicSongInterface:
         song_metadata: dict | None = None,
         webplayback: dict | None = None,
     ) -> StreamInfoAv | None:
-        for codec in self.codec_priority:
-            if codec.is_legacy():
-                return await self._get_stream_info_legacy(webplayback, codec)
-            else:
-                return await self._get_stream_info(song_metadata, codec)
+        if SongCodec.ASK not in self.codec_priority:
+            for codec in self.codec_priority:
+                if codec.is_legacy():
+                    stream_info = await self._get_stream_info_legacy(webplayback, codec)
+                else:
+                    stream_info = await self._get_stream_info(song_metadata, codec)
+
+                if stream_info is not None:
+                    return stream_info
+
+        else:
+            return await self._get_stream_info(song_metadata, SongCodec.ASK)
+
 
     async def get_wrapper_m3u8(self, adam_id: str) -> str | None:
         host, port = self.base.wrapper_m3u8_ip.split(":")


### PR DESCRIPTION
The `--song-codec-priority` option stopped recognizing fallback codecs in 3.0, this PR restores the functionality (similarly to how the `--music-video-codec-priority` functions).

Fixes #296.