### PR TITLE
Fix BUG --use-album-date not applying to song tag generation

### DIFF
--- a/gamdl/interface/song.py
+++ b/gamdl/interface/song.py
@@ -558,11 +558,13 @@ class AppleMusicSongInterface:
             media.tags = await self.base.get_tags_from_asset_info(
                 playback["songList"][0]["assets"][0]["metadata"],
                 media.lyrics.unsynced if media.lyrics else None,
+                self.use_album_date,
             )
         else:
             media.tags = await self.base.get_tags_from_asset_info(
                 webplayback["songList"][0]["assets"][0]["metadata"],
                 media.lyrics.unsynced if media.lyrics else None,
+                self.use_album_date,
             )
 
         if not self.skip_stream_info:


### PR DESCRIPTION
Fix #317 

AI-generated PR.

## Issue

The `--use-album-date` option was accepted by the CLI and stored on `AppleMusicSongInterface`, but it was no longer being passed into `get_tags_from_asset_info()` during song tag generation.

As a result, song downloads always used the track asset `releaseDate`, even when `--use-album-date` was enabled. This affected both wrapper-backed playback metadata and regular web playback metadata.

## Regression

This option was originally added in commit `6ed596c` (`2026-01-03 14:43:55 -0300`), and it was still correctly forwarded through the wrapper and non-wrapper song paths after commit `86bbb94` (`2026-05-18 14:05:33 -0300`).

The behavior regressed in commit `c75249b` (`2026-05-23 15:47:29 -0300`, `Support Apple Music library songs streaming`). That refactor split the song metadata flow into `playback` and `webplayback` branches, but dropped the `self.use_album_date` argument when calling `get_tags_from_asset_info()`.

## Root Cause

The helper still supported `use_album_date`, but the song interface no longer forwarded the configured value:

```python
self.base.get_tags_from_asset_info(...)
```

Because `get_tags_from_asset_info()` defaults `use_album_date` to `False`, the option became ineffective.

## Fix

Pass `self.use_album_date` into `get_tags_from_asset_info()` in both song tag paths:

- wrapper playback path
- webplayback fallback path

## Result

`--use-album-date` now correctly causes song tags to use the album release date lookup via the album `playlistId`, restoring the intended behavior for both wrapper and non-wrapper song downloads.

## Verification

Ran:

```bash
python3 -m compileall gamdl
```

Compilation completed successfully.