### PR TITLE
Fix token extraction and cover art timeout

### DIFF
--- a/gamdl/api/apple_music.py
+++ b/gamdl/api/apple_music.py
@@ -93,7 +93,7 @@ class AppleMusicApi:
                 )
 
         index_js_uri_match = re.search(
-            r"/(assets/index-legacy[~-][^/\"]+\.js)",
+            r"/(assets/index[~-][^/\"]+\.js)",
             home_page,
         )
         if not index_js_uri_match:
@@ -116,7 +116,7 @@ class AppleMusicApi:
                     status_code=response.status_code if response is not None else None,
                 )
 
-        token_match = re.search('(?=eyJh)(.*?)(?=")', index_js_page)
+        token_match = re.search(r'"(eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+)"', index_js_page)
         if not token_match:
             raise GamdlApiResponseError("Error finding token in index.js page")
         token = token_match.group(1)

--- a/gamdl/interface/base.py
+++ b/gamdl/interface/base.py
@@ -205,8 +205,8 @@ class AppleMusicBaseInterface:
     async def get_cover_bytes(self, cover_url: str) -> bytes | None:
         log = logger.bind(action="get_cover_bytes", cover_url=cover_url)
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(cover_url)
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(cover_url, follow_redirects=True)
 
             if response.status_code == 404:
                 log.debug("cover_not_found")


### PR DESCRIPTION
- Search non-legacy index JS bundle for token (Apple moved it from index-legacy)
- Broaden JWT regex from eyJh to full 3-part JWT pattern (tokens now start with eyJ0)
- Add 30s timeout and follow_redirects to cover art fetch to avoid ConnectTimeout