### PR TITLE
fix: handle music video cover URL template in _get_raw_cover_url

### DIFF
--- a/gamdl/interface/base.py
+++ b/gamdl/interface/base.py
@@ -228,7 +228,7 @@ class AppleMusicBaseInterface:
 
     def _get_raw_cover_url(self, cover_url_template: str) -> str:
         return re.sub(
-            r"/\{w\}x\{h\}bb\.jpg",
+            r"/\{w\}x\{h\}(?:bb|mv)\.jpg",
             "",
             re.sub(
                 r"image/thumb/",


### PR DESCRIPTION
Music video covers were failing with a 400 when using `--cover-format raw`. Turns out `_get_raw_cover_url` only stripped `/{w}x{h}bb.jpg` but music video artwork URLs end with `mv.jpg` instead of `bb.jpg`.

I was getting this kind of error:
```
httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://a1.mzstatic.com/Video221/v4/ff/fb/29/fffb2984-a27c-b69c-c651-31a1d68862f8/24UM1IM41125.crop.jpg/%7Bw%7Dx%7Bh
%7Dmv.jpg'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
[ERROR    20:26:57] [Track   7/8  ] Error downloading "THE GREATEST (Artist of the Year 2024 Live)"
```

Just added `mv` as an alternative in the regex.


P.S. I forget to create a feature branch on the previous PR, since I'm trying to add word-by-word synced lyrics download support I thought I'd clean up the mess I made. Sorry.