### PR TITLE
Increase httpx client timeout when fetching apples homepage

### DIFF
--- a/gamdl/api/apple_music.py
+++ b/gamdl/api/apple_music.py
@@ -79,7 +79,8 @@ class AppleMusicApi:
         log = logger.bind(action="get_token")
 
         response = None
-        async with httpx.AsyncClient() as client:
+        timeout = 30.0
+        async with httpx.AsyncClient(timeout=timeout) as client:
             try:
                 response = await client.get(
                     APPLE_MUSIC_HOMEPAGE_URL,


### PR DESCRIPTION
Currently at a place with weak wifi, noticed i would get this timeout error when running gamdl:

Traceback (most recent call last):
  File "/home/v4h/Music/venv/lib/python3.14/site-packages/gamdl/api/apple_music.py", line 84, in get_token
    response = await client.get(
               ^^^^^^^^^^^^^^^^^
    ...<2 lines>...
  
So i extended the default timeout to 30 seconds and it ended up working normal again. Decided to make this PR, hope this helps in some way!