### PR TITLE
Exclude Cargo target dir from wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,4 @@ module-name = "gamdl._ammuxer"
 python-source = "."
 features = ["pyo3/extension-module"]
 include = ["LICENSE"]
+exclude = ["**/target/**"]


### PR DESCRIPTION
`python-source = "."` pulls the crate's `target/` (and the wheel being written) into the wheel itself
 → 4 GiB zip error on sdist builds from homebrew build

`.gitignore` saves git checkouts but isn't in sdists. One-line `exclude` sorts it out.