### PR TITLE
Fix long filename handling and separate character/byte truncation limits

### DIFF
--- a/gamdl/cli/cli.py
+++ b/gamdl/cli/cli.py
@@ -285,6 +285,7 @@ async def main(config: CliConfig):
                 except Exception as e:
                     error_count += 1
                     track_log.exception(f'Error downloading "{media_title}"')
+                    continue
 
                 if (
                     database

--- a/gamdl/cli/database.py
+++ b/gamdl/cli/database.py
@@ -51,8 +51,13 @@ class Database:
         if not result:
             return None
 
+        try:
+            path_exists = Path(result).exists()
+        except OSError:
+            return None
+
         return (
             "Registered in database"
-            if Path(result).exists() and not self.overwrite
+            if path_exists and not self.overwrite
             else None
         )

--- a/gamdl/downloader/base.py
+++ b/gamdl/downloader/base.py
@@ -21,6 +21,8 @@ from .enums import DownloadMode
 
 logger = structlog.get_logger(__name__)
 
+MAX_FILENAME_BYTES = 255
+
 
 def _download_ytdlp_process(
     stream_url: str,
@@ -154,14 +156,29 @@ class AppleMusicBaseDownloader:
 
         if file_ext is None:
             sanitized_string = sanitized_string[: self.truncate]
+            sanitized_string = self._truncate_to_bytes(sanitized_string, MAX_FILENAME_BYTES)
             if sanitized_string.endswith("."):
                 sanitized_string = sanitized_string[:-1] + ILLEGAL_CHAR_REPLACEMENT
         else:
             if self.truncate is not None:
-                sanitized_string = sanitized_string[: self.truncate - len(file_ext)]
+                sanitized_string = sanitized_string[: max(self.truncate - len(file_ext), 0)]
+            
+            file_ext_bytes = len(file_ext.encode("utf-8"))
+            sanitized_string = self._truncate_to_bytes(
+                sanitized_string,
+                max(MAX_FILENAME_BYTES - file_ext_bytes, 0),
+            )
             sanitized_string += file_ext
 
         return sanitized_string.strip()
+
+    @staticmethod
+    def _truncate_to_bytes(value: str, max_bytes: int) -> str:
+        encoded_value = value.encode("utf-8")
+        if len(encoded_value) <= max_bytes:
+            return value
+
+        return encoded_value[:max_bytes].decode("utf-8", errors="ignore")
 
     def get_final_path(
         self,


### PR DESCRIPTION
Reopened from #324, rebased on the latest `main` to resolve conflicts with recent changes.

## Description

This PR fixes `OSError: [Errno 36] File name too long` when generated output filenames exceed the filesystem byte limit.

The issue is more likely with CJK titles because filename limits are byte-based, not character-based. For example:

```
2-01 Medley_ 前程锦绣 _ 喜气洋洋 _ 甜蜜如软糖 _ 流非飞 _ 不羁的风 (Live).m4a
```

The ASCII characters are mostly 1 byte each, while each Chinese character is usually 3 bytes in UTF-8. So a filename can be under 255 visible characters but still exceed the common 255-byte filename limit.

This is not limited to Chinese. Any filename containing many non-ASCII characters can hit this issue, including Japanese, Korean, emoji, and other writing systems. The filename may look shorter than 255 visible characters, but still exceed the filesystem's byte-based limit because UTF-8 encodes many of these characters as multiple bytes.

## Changes

- **`gamdl/downloader/base.py`**: Caps each generated path component at 255 UTF-8 bytes. Applies `--truncate` as a character limit first, then enforces the byte limit independently. Counts the file extension inside the filename byte budget.
- **`gamdl/cli/cli.py`**: Stops writing download entries to the database after unexpected download errors.
- **`gamdl/cli/database.py`**: Treats unstatable historical database paths as missing, so old bad entries do not crash future runs.
